### PR TITLE
Amend filter command behaviour

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -285,9 +285,9 @@ Format: `filter [--name NAME]... [--phone PHONE]... [--email EMAIL]... [--status
 - With repeated `--name`, `--phone`, `--email`, or `--status`, profiles match any of the specified values.
   e.g. `--name John --name Jane` matches persons whose name contains `John` or `Jane`.
 - `NAME`, `EMAIL`, and `PHONE` conditions require case-insensitive partial match.
-- `--phone NONE` (case-insensitive) matches persons with no phone field.
-- `--email NONE` (exact fully uppercase word) matches persons with no email field.
-- `--email none` (case-insensitive) matches persons whose email contains the substring `none`.
+- `--phone NONE` or `--email NONE` (exact fully uppercase word) matches persons with no phone/email.
+- `--email none` (and other case variations apart from `NONE`) matches persons whose email address contains `none`
+  e.g. `--email NoNe` matches a person with email `anone@gmail.com`
 - `STATUS` must be one of `none`, `target`, `scam`, or `ignore` (case-insensitive).
 - `--tag TAGNAME` checks whether a person has a tag with that name. `TAGNAME` must be a valid tag name, according to [this](#tag-constraints).
 - `--tag TAGNAME:TAGVALUE` checks whether a person has a tag with that name whose value contains `TAGVALUE`.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -285,7 +285,9 @@ Format: `filter [--name NAME]... [--phone PHONE]... [--email EMAIL]... [--status
 - With repeated `--name`, `--phone`, `--email`, or `--status`, profiles match any of the specified values.
   e.g. `--name John --name Jane` matches persons whose name contains `John` or `Jane`.
 - `NAME`, `EMAIL`, and `PHONE` conditions require case-insensitive partial match.
-- `--phone NONE` matches persons with no phone field, and `--email NONE` matches persons with no email field.
+- `--phone NONE` (case-insensitive) matches persons with no phone field.
+- `--email NONE` (exact fully uppercase word) matches persons with no email field.
+- `--email none` (case-insensitive) matches persons whose email contains the substring `none`.
 - `STATUS` must be one of `none`, `target`, `scam`, or `ignore` (case-insensitive).
 - `--tag TAGNAME` checks whether a person has a tag with that name. `TAGNAME` must be a valid tag name, according to [this](#tag-constraints).
 - `--tag TAGNAME:TAGVALUE` checks whether a person has a tag with that name whose value contains `TAGVALUE`.
@@ -480,7 +482,7 @@ Emails should follow the format `local-part@domain` (e.g. `john.doe@example.com`
 ScamBook accepts a broader set of [RFC 5322 standards-compliant email addresses](https://datatracker.ietf.org/doc/html/rfc5322#section-3.4.1).
 
 <box type="tip" seamless>
-<b>Tip:</b> <code>filter --email</code> accepts any non-empty substring for matching (except the reserved keyword <code>NONE</code>, which matches missing email) and does not require a full valid email format.
+<b>Tip:</b> <code>filter --email</code> accepts any non-empty substring for matching (except the reserved keyword <code>NONE</code> (exact fully uppercase word), which matches missing email) and does not require a full valid email format.
 </box>
 
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -281,6 +281,9 @@ Format: `filter [--name NAME]... [--phone PHONE]... [--email EMAIL]... [--status
 - With repeated `--name`, `--phone`, `--email`, or `--status`, profiles match any of the specified values.
   e.g. `--name John --name Jane` matches persons whose name contains `John` or `Jane`.
 - `NAME`, `EMAIL`, and `PHONE` conditions require case-insensitive partial match.
+- `--phone NONE` matches persons with no phone field, and `--email NONE` matches persons with no email field.
+- For phone or email filtering, `NONE` can be mixed with normal substrings.
+  e.g. `--phone NONE --phone 9876` matches persons with no phone or with a phone containing `9876`.
 - `STATUS` must be one of `NONE`, `TARGET`, `SCAM`, or `IGNORE` (case-insensitive).
 - `--tag TAGNAME` checks whether a person has a tag with that name. `TAGNAME` must be a valid tag name, according to [this](#tag-constraints).
 - `--tag TAGNAME:TAGVALUE` checks whether a person has a tag with that name whose value contains `TAGVALUE`.
@@ -298,6 +301,8 @@ Examples:
   Shows all persons whose status is either `TARGET` or `SCAM`.
 - `filter --phone 9876 --email gmail.com`
   Shows all persons whose phone number contains `9876` and whose email contains `gmail.com`.
+- `filter --phone NONE --email NONE`
+  Shows all persons with no phone and no email.
 - `filter --tag job`
   Shows all persons who have a tag named `job`, regardless of its value.
 - `filter --tag job:manager --tag job:director`
@@ -463,7 +468,7 @@ Emails should follow the format `local-part@domain` (e.g. `john.doe@example.com`
 ScamBook accepts a broader set of [RFC 5322 standards-compliant email addresses](https://datatracker.ietf.org/doc/html/rfc5322#section-3.4.1).
 
 <box type="tip" seamless>
-<b>Tip:</b> <code>filter --email</code> accepts any non-empty substring for matching and does not require a full valid email format.
+<b>Tip:</b> <code>filter --email</code> accepts any non-empty substring for matching (except the reserved keyword <code>NONE</code>, which matches missing email) and does not require a full valid email format.
 </box>
 
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -286,8 +286,8 @@ Format: `filter [--name NAME]... [--phone PHONE]... [--email EMAIL]... [--status
   e.g. `--name John --name Jane` matches persons whose name contains `John` or `Jane`.
 - `NAME`, `EMAIL`, and `PHONE` conditions require case-insensitive partial match.
 - `--phone NONE` or `--email NONE` (exact fully uppercase word) matches persons with no phone/email.
-- `--email none` (and other case variations apart from `NONE`) matches persons whose email address contains `none`
-  e.g. `--email NoNe` matches a person with email `anone@gmail.com`
+- `--email none` (and other case variations apart from `NONE`) performs regular email matching, and matches persons whose email address contains `none` (case-insensitive)
+  e.g. `--email NoNe` matches a person with email `anOnE@gmail.com`
 - `STATUS` must be one of `none`, `target`, `scam`, or `ignore` (case-insensitive).
 - `--tag TAGNAME` checks whether a person has a tag with that name. `TAGNAME` must be a valid tag name, according to [this](#tag-constraints).
 - `--tag TAGNAME:TAGVALUE` checks whether a person has a tag with that name whose value contains `TAGVALUE`.

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -186,9 +186,9 @@ public class FilterCommand extends Command {
     }
 
     private Predicate<Person> buildEmailPredicate(List<String> emailFilters) {
-        boolean includesEmptyEmail = emailFilters.stream().anyMatch(this::isEmptyFieldKeyword);
+        boolean includesEmptyEmail = emailFilters.stream().anyMatch(this::isEmptyEmailKeyword);
         List<String> emailSubstrings = emailFilters.stream()
-                .filter(filter -> !isEmptyFieldKeyword(filter))
+                .filter(filter -> !isEmptyEmailKeyword(filter))
                 .collect(Collectors.toList());
 
         Predicate<Person> emailPredicate = null;
@@ -205,6 +205,10 @@ public class FilterCommand extends Command {
 
     private boolean isEmptyFieldKeyword(String value) {
         return EMPTY_FIELD_KEYWORD.equalsIgnoreCase(value.trim());
+    }
+
+    private boolean isEmptyEmailKeyword(String value) {
+        return EMPTY_FIELD_KEYWORD.equals(value.trim());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -186,9 +186,9 @@ public class FilterCommand extends Command {
     }
 
     private Predicate<Person> buildEmailPredicate(List<String> emailFilters) {
-        boolean includesEmptyEmail = emailFilters.stream().anyMatch(this::isEmptyEmailKeyword);
+        boolean includesEmptyEmail = emailFilters.stream().anyMatch(this::isEmptyFieldKeyword);
         List<String> emailSubstrings = emailFilters.stream()
-                .filter(filter -> !isEmptyEmailKeyword(filter))
+                .filter(filter -> !isEmptyFieldKeyword(filter))
                 .collect(Collectors.toList());
 
         Predicate<Person> emailPredicate = null;
@@ -204,10 +204,6 @@ public class FilterCommand extends Command {
     }
 
     private boolean isEmptyFieldKeyword(String value) {
-        return EMPTY_FIELD_KEYWORD.equalsIgnoreCase(value.trim());
-    }
-
-    private boolean isEmptyEmailKeyword(String value) {
         return EMPTY_FIELD_KEYWORD.equals(value.trim());
     }
 

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.ToStringBuilder;
@@ -33,6 +34,7 @@ import seedu.address.model.tag.TagFilter;
 public class FilterCommand extends Command {
 
     public static final String COMMAND_WORD = "filter";
+    public static final String EMPTY_FIELD_KEYWORD = "NONE";
 
     public static final String EXAMPLE = COMMAND_WORD + " "
             + PARAM_ID_NAME + " John "
@@ -48,6 +50,8 @@ public class FilterCommand extends Command {
             + "[" + PARAM_ID_EMAIL + " <email>]... "
             + "[" + PARAM_ID_STATUS + " <status>]... "
             + "[" + PARAM_ID_TAG + " <tagName>[:<tagValue>]]...\n"
+            + "Use " + PARAM_ID_PHONE + " " + EMPTY_FIELD_KEYWORD + " and/or "
+            + PARAM_ID_EMAIL + " " + EMPTY_FIELD_KEYWORD + " to filter missing phone/email fields.\n"
             + "Example: " + EXAMPLE;
 
     public static final String MESSAGE_SUCCESS = "Filtered victim profiles.";
@@ -120,14 +124,20 @@ public class FilterCommand extends Command {
         if (paramFilters.containsKey(FilterType.PHONE)) {
             List<String> phoneFilters = paramFilters.get(FilterType.PHONE);
             if (phoneFilters != null && !phoneFilters.isEmpty()) {
-                predicate = predicate.and(new PhoneContainsPredicate(phoneFilters));
+                Predicate<Person> phonePredicate = buildPhonePredicate(phoneFilters);
+                if (phonePredicate != null) {
+                    predicate = predicate.and(phonePredicate);
+                }
             }
         }
 
         if (paramFilters.containsKey(FilterType.EMAIL)) {
             List<String> emailFilters = paramFilters.get(FilterType.EMAIL);
             if (emailFilters != null && !emailFilters.isEmpty()) {
-                predicate = predicate.and(new EmailContainsPredicate(emailFilters));
+                Predicate<Person> emailPredicate = buildEmailPredicate(emailFilters);
+                if (emailPredicate != null) {
+                    predicate = predicate.and(emailPredicate);
+                }
             }
         }
 
@@ -135,17 +145,17 @@ public class FilterCommand extends Command {
             List<String> statusFilters = paramFilters.get(FilterType.STATUS);
             if (statusFilters != null && !statusFilters.isEmpty()) {
                 List<Status> statuses = statusFilters.stream()
-                        .map(status -> {
-                            try {
-                                return Status.parseStatus(status);
-                            } catch (IllegalValueException e) {
-                                Logger logger = Logger.getLogger(FilterCommand.class.getName());
-                                logger.warning(() -> "Invalid status filter value: " + status
-                                        + ". Skipping this filter.");
-                                return null; // Skip invalid status values
-                            }
-                        })
-                        .toList();
+                    .map(status -> {
+                        try {
+                            return Status.parseStatus(status);
+                        } catch (IllegalValueException e) {
+                            Logger logger = Logger.getLogger(FilterCommand.class.getName());
+                            logger.warning(() -> "Invalid status filter value: " + status
+                                    + ". Skipping this filter.");
+                            return null; // Skip invalid status values
+                        }
+                    })
+                    .toList();
                 predicate = predicate.and(new StatusEqualsPredicate(statuses));
             }
         }
@@ -155,6 +165,46 @@ public class FilterCommand extends Command {
         }
 
         return predicate;
+    }
+
+    private Predicate<Person> buildPhonePredicate(List<String> phoneFilters) {
+        boolean includesEmptyPhone = phoneFilters.stream().anyMatch(this::isEmptyFieldKeyword);
+        List<String> phoneSubstrings = phoneFilters.stream()
+                .filter(filter -> !isEmptyFieldKeyword(filter))
+                .collect(Collectors.toList());
+
+        Predicate<Person> phonePredicate = null;
+        if (!phoneSubstrings.isEmpty()) {
+            phonePredicate = new PhoneContainsPredicate(phoneSubstrings);
+        }
+        if (includesEmptyPhone) {
+            Predicate<Person> noPhonePredicate = person -> !person.hasPhone();
+            phonePredicate = phonePredicate == null ? noPhonePredicate : phonePredicate.or(noPhonePredicate);
+        }
+
+        return phonePredicate;
+    }
+
+    private Predicate<Person> buildEmailPredicate(List<String> emailFilters) {
+        boolean includesEmptyEmail = emailFilters.stream().anyMatch(this::isEmptyFieldKeyword);
+        List<String> emailSubstrings = emailFilters.stream()
+                .filter(filter -> !isEmptyFieldKeyword(filter))
+                .collect(Collectors.toList());
+
+        Predicate<Person> emailPredicate = null;
+        if (!emailSubstrings.isEmpty()) {
+            emailPredicate = new EmailContainsPredicate(emailSubstrings);
+        }
+        if (includesEmptyEmail) {
+            Predicate<Person> noEmailPredicate = person -> !person.hasEmail();
+            emailPredicate = emailPredicate == null ? noEmailPredicate : emailPredicate.or(noEmailPredicate);
+        }
+
+        return emailPredicate;
+    }
+
+    private boolean isEmptyFieldKeyword(String value) {
+        return EMPTY_FIELD_KEYWORD.equalsIgnoreCase(value.trim());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -215,7 +215,7 @@ public class SortCommand extends Command {
     }
 
     private String getTagValue(Person person, String tagName) {
-        return person.getTags().filterTagCaseInsensitive(tagName).orElse(null);
+        return person.getTags().getTagValueCaseInsensitive(tagName).orElse(null);
     }
 
     private Long parseLongOrNull(String value) {

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -134,7 +134,7 @@ public class SortCommand extends Command {
 
     private void requireTagExists(Model model, String tagName) throws CommandException {
         boolean tagExists = model.getAddressBook().getPersonList().stream()
-                .anyMatch(person -> person.getTags().filterTagCaseInsensitive(tagName).isPresent());
+                .anyMatch(person -> person.getTags().getTagValueCaseInsensitive(tagName).isPresent());
 
         if (!tagExists) {
             throw new CommandException(String.format(MESSAGE_UNKNOWN_TAG, tagName));

--- a/src/main/java/seedu/address/logic/parser/inputpatterns/FilterEmailParam.java
+++ b/src/main/java/seedu/address/logic/parser/inputpatterns/FilterEmailParam.java
@@ -6,6 +6,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 
 /**
  * A filter-only param that accepts any non-empty email substring.
+ * The value {@code NONE} is interpreted by {@code FilterCommand} as a missing email field.
  */
 public class FilterEmailParam extends Param {
 
@@ -15,7 +16,7 @@ public class FilterEmailParam extends Param {
 
     @Override
     public String getPreview() {
-        return PARAM_ID_EMAIL + " <email_substring>";
+        return PARAM_ID_EMAIL + " <email_substring|NONE>";
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/inputpatterns/FilterPhoneParam.java
+++ b/src/main/java/seedu/address/logic/parser/inputpatterns/FilterPhoneParam.java
@@ -6,6 +6,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 
 /**
  * A filter-only param that accepts any non-empty phone substring.
+ * The value {@code NONE} is interpreted by {@code FilterCommand} as a missing phone field.
  */
 public class FilterPhoneParam extends Param {
 
@@ -15,7 +16,7 @@ public class FilterPhoneParam extends Param {
 
     @Override
     public String getPreview() {
-        return PARAM_ID_PHONE + " <phone_substring>";
+        return PARAM_ID_PHONE + " <phone_substring|NONE>";
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/TagList.java
+++ b/src/main/java/seedu/address/model/person/TagList.java
@@ -80,12 +80,26 @@ public class TagList {
     }
 
     /**
+     * Returns a list containing the values of tags with names containing the given search string,
+     * ignoring case, if it exists.
+     *
+     * @param searchString The substring for the tag names to search for, case-insensitive.
+     * @return A list containing the values of any tags found, or an empty list if none found.
+     */
+    public List<String> filterTagCaseInsensitive(String searchString) {
+        return this.tags.entrySet().stream()
+                .filter(tag -> tag.getKey().toLowerCase().contains(searchString.toLowerCase()))
+                .map(Map.Entry::getValue)
+                .toList();
+    }
+
+    /**
      * Returns an Optional containing the value of the tag with the given name, ignoring case, if it exists.
      *
      * @param tagName The name of the tag to search for, case-insensitive.
      * @return An Optional containing the value of the tag if found, or an empty Optional if not found.
      */
-    public Optional<String> filterTagCaseInsensitive(String tagName) {
+    public Optional<String> getTagValueCaseInsensitive(String tagName) {
         return this.tags.entrySet().stream()
                 .filter(tag -> tag.getKey().equalsIgnoreCase(tagName))
                 .findFirst()

--- a/src/main/java/seedu/address/model/person/predicates/TagContainsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/TagContainsPredicate.java
@@ -27,9 +27,9 @@ public class TagContainsPredicate implements Predicate<Person> {
     public boolean test(Person person) {
         TagList personTags = person.getTags();
 
-        // Group tagFilters by tag name
+        // Group tagFilters by tag name (case-insensitive)
         Map<String, List<TagFilter>> tagFilterGroups = tagFilters.stream()
-                .collect(Collectors.groupingBy(tf -> tf.tagName));
+                .collect(Collectors.groupingBy(tf -> tf.getTagName().toLowerCase()));
 
         // Check that for each tag filter group, at least one tag filter matches the person's tags
         return tagFilterGroups.values().stream()
@@ -38,11 +38,10 @@ public class TagContainsPredicate implements Predicate<Person> {
     }
 
     private boolean matchesTagFilter(TagList personTags, TagFilter tagFilter) {
-        return personTags.filterTagCaseInsensitive(tagFilter.tagName)
-                .filter(tagValue -> tagFilter.getTagValue()
+        return personTags.filterTagCaseInsensitive(tagFilter.getTagName()).stream()
+                .anyMatch(tagValue -> tagFilter.getTagValue()
                         .map(expectedValue -> tagValue.toLowerCase().contains(expectedValue.toLowerCase()))
-                        .orElse(true))
-                .isPresent();
+                        .orElse(true));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/tag/TagFilter.java
+++ b/src/main/java/seedu/address/model/tag/TagFilter.java
@@ -11,7 +11,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
  * Represents a filter on a tag, either by tag name alone or by tag name and value.
  */
 public class TagFilter {
-    public final String tagName;
+    private final String tagName;
     private final String tagValue;
 
     /**
@@ -36,6 +36,10 @@ public class TagFilter {
         } catch (IllegalValueException e) {
             throw new IllegalArgumentException(e.getMessage());
         }
+    }
+
+    public String getTagName() {
+        return tagName;
     }
 
     public Optional<String> getTagValue() {

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -39,6 +39,7 @@ import seedu.address.model.person.predicates.PhoneContainsPredicate;
 import seedu.address.model.person.predicates.StatusEqualsPredicate;
 import seedu.address.model.person.predicates.TagContainsPredicate;
 import seedu.address.model.tag.TagFilter;
+import seedu.address.testutil.PersonBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for FilterCommand.
@@ -374,6 +375,33 @@ public class FilterCommandTest {
 
         expectedModel.updateFilteredPersonList(person -> !person.hasEmail());
         assertFilterResult(command, model, List.of(SILENT));
+    }
+
+    @Test
+    public void execute_emailNoneLowercase_treatedAsSubstring() {
+        model.addPerson(SILENT);
+        expectedModel.addPerson(SILENT);
+
+        FilterCommand command = createFilterCommand(singleParamFilter(FilterType.EMAIL, "none"),
+                Collections.emptyList());
+
+        expectedModel.updateFilteredPersonList(new EmailContainsPredicate(List.of("none")));
+        assertFilterResult(command, model, Collections.emptyList());
+    }
+
+    @Test
+    public void execute_emailNoneLowercase_canMatchLiteralNoneSubstring() {
+        var noneEmailPerson = new PersonBuilder().withName("Nora None")
+                .withEmail("none@example.com")
+                .build();
+        model.addPerson(noneEmailPerson);
+        expectedModel.addPerson(noneEmailPerson);
+
+        FilterCommand command = createFilterCommand(singleParamFilter(FilterType.EMAIL, "none"),
+                Collections.emptyList());
+
+        expectedModel.updateFilteredPersonList(new EmailContainsPredicate(List.of("none")));
+        assertFilterResult(command, model, List.of(noneEmailPerson));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -220,15 +220,15 @@ public class FilterCommandTest {
     }
 
     @Test
-    public void execute_phoneNoneCaseInsensitive_filtersPersonsWithoutPhone() {
+    public void execute_phoneNoneLowercase_treatedAsSubstring() {
         model.addPerson(SILENT);
         expectedModel.addPerson(SILENT);
 
         FilterCommand command = createFilterCommand(singleParamFilter(FilterType.PHONE, "none"),
                 Collections.emptyList());
 
-        expectedModel.updateFilteredPersonList(person -> !person.hasPhone());
-        assertFilterResult(command, model, List.of(SILENT));
+        expectedModel.updateFilteredPersonList(new PhoneContainsPredicate(List.of("none")));
+        assertFilterResult(command, model, Collections.emptyList());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -14,6 +14,7 @@ import static seedu.address.testutil.TypicalPersons.DANIEL;
 import static seedu.address.testutil.TypicalPersons.ELLE;
 import static seedu.address.testutil.TypicalPersons.FIONA;
 import static seedu.address.testutil.TypicalPersons.GEORGE;
+import static seedu.address.testutil.TypicalPersons.SILENT;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
@@ -21,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -205,6 +207,43 @@ public class FilterCommandTest {
     }
 
     @Test
+    public void execute_phoneNone_filtersPersonsWithoutPhone() {
+        model.addPerson(SILENT);
+        expectedModel.addPerson(SILENT);
+
+        FilterCommand command = createFilterCommand(singleParamFilter(FilterType.PHONE, "NONE"),
+                Collections.emptyList());
+
+        expectedModel.updateFilteredPersonList(person -> !person.hasPhone());
+        assertFilterResult(command, model, List.of(SILENT));
+    }
+
+    @Test
+    public void execute_phoneNoneCaseInsensitive_filtersPersonsWithoutPhone() {
+        model.addPerson(SILENT);
+        expectedModel.addPerson(SILENT);
+
+        FilterCommand command = createFilterCommand(singleParamFilter(FilterType.PHONE, "none"),
+                Collections.emptyList());
+
+        expectedModel.updateFilteredPersonList(person -> !person.hasPhone());
+        assertFilterResult(command, model, List.of(SILENT));
+    }
+
+    @Test
+    public void execute_phoneNoneAndSubstring_filtersByEitherCondition() {
+        model.addPerson(SILENT);
+        expectedModel.addPerson(SILENT);
+
+        FilterCommand command = createFilterCommand(singleParamFilter(FilterType.PHONE, "NONE", "9435"),
+                Collections.emptyList());
+
+        expectedModel.updateFilteredPersonList(
+                new PhoneContainsPredicate(List.of("9435")).or(person -> !person.hasPhone()));
+        assertFilterResult(command, model, List.of(ALICE, SILENT));
+    }
+
+    @Test
     public void execute_singleEmailCriteria_filtersCorrectly() {
         FilterCommand command = createFilterCommand(singleParamFilter(FilterType.EMAIL, "alice@example.com"),
                 Collections.emptyList());
@@ -323,6 +362,31 @@ public class FilterCommandTest {
 
         expectedModel.updateFilteredPersonList(new EmailContainsPredicate(List.of("nonexistent@example.com")));
         assertFilterResult(command, model, Collections.emptyList());
+    }
+
+    @Test
+    public void execute_emailNone_filtersPersonsWithoutEmail() {
+        model.addPerson(SILENT);
+        expectedModel.addPerson(SILENT);
+
+        FilterCommand command = createFilterCommand(singleParamFilter(FilterType.EMAIL, "NONE"),
+                Collections.emptyList());
+
+        expectedModel.updateFilteredPersonList(person -> !person.hasEmail());
+        assertFilterResult(command, model, List.of(SILENT));
+    }
+
+    @Test
+    public void execute_emailNoneAndSubstring_filtersByEitherCondition() {
+        model.addPerson(SILENT);
+        expectedModel.addPerson(SILENT);
+
+        FilterCommand command = createFilterCommand(singleParamFilter(FilterType.EMAIL, "NONE", "alice@example"),
+                Collections.emptyList());
+
+        expectedModel.updateFilteredPersonList(
+                new EmailContainsPredicate(List.of("alice@example")).or(person -> !person.hasEmail()));
+        assertFilterResult(command, model, List.of(ALICE, SILENT));
     }
 
     @Test
@@ -585,5 +649,27 @@ public class FilterCommandTest {
         assertTrue(result.contains("FilterCommand"));
         assertTrue(result.contains("filterCriteria"));
         assertTrue(result.contains("tagFilters"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void buildPhonePredicate_emptyFilters_returnsNull() throws Exception {
+        FilterCommand command = createFilterCommand(new HashMap<>(), Collections.emptyList());
+        var method = FilterCommand.class.getDeclaredMethod("buildPhonePredicate", List.class);
+        method.setAccessible(true);
+
+        Predicate<?> result = (Predicate<?>) method.invoke(command, Collections.emptyList());
+        assertNull(result);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void buildEmailPredicate_emptyFilters_returnsNull() throws Exception {
+        FilterCommand command = createFilterCommand(new HashMap<>(), Collections.emptyList());
+        var method = FilterCommand.class.getDeclaredMethod("buildEmailPredicate", List.class);
+        method.setAccessible(true);
+
+        Predicate<?> result = (Predicate<?>) method.invoke(command, Collections.emptyList());
+        assertNull(result);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -116,6 +116,20 @@ public class FilterCommandParserTest {
     }
 
     @Test
+    public void parse_phoneNoneCriteria_returnsFilterCommand() throws Exception {
+        FilterCommand expected = createExpectedFilterCommand(singleParamFilter(FilterType.PHONE, "NONE"),
+                Collections.emptyList());
+        assertParseSuccess(parser, " --phone NONE", expected);
+    }
+
+    @Test
+    public void parse_emailNoneCriteria_returnsFilterCommand() throws Exception {
+        FilterCommand expected = createExpectedFilterCommand(singleParamFilter(FilterType.EMAIL, "NONE"),
+                Collections.emptyList());
+        assertParseSuccess(parser, " --email NONE", expected);
+    }
+
+    @Test
     public void parse_singleStatusCriteria_returnsFilterCommand() throws Exception {
         FilterCommand expected = createExpectedFilterCommand(singleParamFilter(FilterType.STATUS, "TARGET"),
                 Collections.emptyList());

--- a/src/test/java/seedu/address/logic/parser/inputpatterns/FilterEmailParamTest.java
+++ b/src/test/java/seedu/address/logic/parser/inputpatterns/FilterEmailParamTest.java
@@ -12,7 +12,7 @@ class FilterEmailParamTest {
     public void filterEmailParam_getPreview_returnsExpectedFormat() {
         FilterEmailParam param = new FilterEmailParam(0, 100);
 
-        assertEquals(PARAM_ID_EMAIL + " <email_substring>", param.getPreview());
+        assertEquals(PARAM_ID_EMAIL + " <email_substring|NONE>", param.getPreview());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/inputpatterns/FilterPhoneParamTest.java
+++ b/src/test/java/seedu/address/logic/parser/inputpatterns/FilterPhoneParamTest.java
@@ -12,7 +12,7 @@ class FilterPhoneParamTest {
     public void filterPhoneParam_getPreview_returnsExpectedFormat() {
         FilterPhoneParam param = new FilterPhoneParam(0, 100);
 
-        assertEquals(PARAM_ID_PHONE + " <phone_substring>", param.getPreview());
+        assertEquals(PARAM_ID_PHONE + " <phone_substring|NONE>", param.getPreview());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/TagListTest.java
+++ b/src/test/java/seedu/address/model/person/TagListTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -67,9 +68,34 @@ public class TagListTest {
     }
 
     @Test
+    public void getTagValueCaseInsensitive_success() {
+        TagList tagList1 = new TagList(tagString1, tagString3);
+
+        assertEquals(Optional.of("engineer"), tagList1.getTagValueCaseInsensitive("job"));
+        assertEquals(Optional.of("engineer"), tagList1.getTagValueCaseInsensitive("JOB"));
+        assertEquals(Optional.of("FASS"), tagList1.getTagValueCaseInsensitive("FaCuLtY"));
+    }
+
+    @Test
+    public void getTagValueCaseInsensitive_tagMissingReturnsEmpty() {
+        TagList tagList1 = new TagList(tagString1, tagString3);
+
+        assertEquals(Optional.empty(), tagList1.getTagValueCaseInsensitive("salary"));
+    }
+
+    @Test
     public void equals_with_self() {
         TagList tagList1 = new TagList(tagString1, tagString3);
         assertEquals(tagList1, tagList1);
+    }
+
+    @Test
+    public void hashCode_sameValues_sameHashCode() {
+        TagList tagList1 = new TagList(tagString1, tagString3);
+        TagList tagList2 = new TagList(List.of(tag1, tag3));
+
+        assertEquals(tagList1, tagList2);
+        assertEquals(tagList1.hashCode(), tagList2.hashCode());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/predicates/TagContainsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/TagContainsPredicateTest.java
@@ -42,106 +42,93 @@ public class TagContainsPredicateTest {
     }
 
     @Test
-    public void test_personHasMatchingTags_returnsTrue() {
-        // Single tag matches
+    public void test_emptyFilters_matchesAnyPerson() {
+        TagContainsPredicate predicate = new TagContainsPredicate(Collections.emptyList());
+        assertTrue(predicate.test(new PersonBuilder().withTags("department:engineering").build()));
+        assertTrue(predicate.test(new PersonBuilder().build()));
+    }
+
+    @Test
+    public void testSingleFilterNameAndValue_matchesCaseInsensitively() {
         TagContainsPredicate predicate = new TagContainsPredicate(
                 Collections.singletonList(new TagFilter("department:engineering")));
         assertTrue(predicate.test(new PersonBuilder().withTags("department:engineering").build()));
 
-        // Multiple tags required - person has all of them
-        predicate = new TagContainsPredicate(Arrays.asList(
-                new TagFilter("department:engineering"),
-                new TagFilter("level:senior")));
-        assertTrue(predicate.test(new PersonBuilder()
-                .withTags("department:engineering", "level:senior").build()));
-
-        // Multiple tags required - person has all plus extra
-        predicate = new TagContainsPredicate(Arrays.asList(
-                new TagFilter("department:engineering"),
-                new TagFilter("level:senior")));
-        assertTrue(predicate.test(new PersonBuilder()
-                .withTags("department:engineering", "level:senior", "project:webapp").build()));
-
-        // Tag name matches case-insensitively
         predicate = new TagContainsPredicate(
                 Collections.singletonList(new TagFilter("Department:engineering")));
         assertTrue(predicate.test(new PersonBuilder().withTags("department:engineering").build()));
 
-        // Tag value matches case-insensitively
         predicate = new TagContainsPredicate(
                 Collections.singletonList(new TagFilter("department:ENGINEERING")));
         assertTrue(predicate.test(new PersonBuilder().withTags("department:engineering").build()));
+    }
 
-        // Bare tag name checks for existence only
-        predicate = new TagContainsPredicate(Collections.singletonList(new TagFilter("department")));
+    @Test
+    public void testSingleFilterNameAndValue_usesSubstringMatching() {
+        TagContainsPredicate predicate = new TagContainsPredicate(
+                Collections.singletonList(new TagFilter("part:engine")));
         assertTrue(predicate.test(new PersonBuilder().withTags("department:engineering").build()));
 
-        // Filters with the same tag name are OR-ed together
-        predicate = new TagContainsPredicate(Arrays.asList(
+        predicate = new TagContainsPredicate(Collections.singletonList(new TagFilter("part")));
+        assertTrue(predicate.test(new PersonBuilder().withTags("department:engineering").build()));
+    }
+
+    @Test
+    public void test_sameTagNameFilters_areOrCombined() {
+        // same tag-name group: department=sales OR department=engineering
+        TagContainsPredicate predicate = new TagContainsPredicate(Arrays.asList(
                 new TagFilter("department:sales"),
                 new TagFilter("department:engineering")));
         assertTrue(predicate.test(new PersonBuilder().withTags("department:engineering").build()));
+    }
 
-        // Same-name filters are OR-ed, then AND-ed with other tag-name groups
-        predicate = new TagContainsPredicate(Arrays.asList(
+    @Test
+    public void test_differentTagNameGroups_areAndCombined() {
+        // (department=sales OR department=engineering) AND level=senior
+        TagContainsPredicate predicate = new TagContainsPredicate(Arrays.asList(
                 new TagFilter("department:sales"),
                 new TagFilter("department:engineering"),
                 new TagFilter("level:senior")));
         assertTrue(predicate.test(new PersonBuilder()
                 .withTags("department:engineering", "level:senior").build()));
+        assertTrue(predicate.test(new PersonBuilder()
+                .withTags("department:engineering", "level:senior", "project:webapp").build()));
     }
 
     @Test
-    public void test_personDoesNotHaveMatchingTags_returnsFalse() {
-        // Zero tags in predicate
-        TagContainsPredicate predicate = new TagContainsPredicate(Collections.emptyList());
-        assertTrue(predicate.test(new PersonBuilder().withTags("department:engineering").build()));
-
-        // Non-matching tag name
-        predicate = new TagContainsPredicate(
+    public void testSingleFilterNonMatchingName_returnsFalse() {
+        TagContainsPredicate predicate = new TagContainsPredicate(
                 Collections.singletonList(new TagFilter("role:manager")));
         assertFalse(predicate.test(new PersonBuilder().withTags("department:engineering").build()));
+    }
 
-        // Non-matching tag value
-        predicate = new TagContainsPredicate(
+    @Test
+    public void testSingleFilterNonMatchingValue_returnsFalse() {
+        TagContainsPredicate predicate = new TagContainsPredicate(
                 Collections.singletonList(new TagFilter("department:sales")));
         assertFalse(predicate.test(new PersonBuilder().withTags("department:engineering").build()));
+    }
 
-        // Multiple tags required but person has only one
-        predicate = new TagContainsPredicate(Arrays.asList(
+    @Test
+    public void testDifferentTagNameGroupsMissingOneGroup_returnsFalse() {
+        TagContainsPredicate predicate = new TagContainsPredicate(Arrays.asList(
                 new TagFilter("department:engineering"),
                 new TagFilter("level:senior")));
         assertFalse(predicate.test(new PersonBuilder().withTags("department:engineering").build()));
-
-        // Multiple tags required but person doesn't have any of them
-        predicate = new TagContainsPredicate(Arrays.asList(
-                new TagFilter("department:sales"),
-                new TagFilter("level:junior")));
-        assertFalse(predicate.test(new PersonBuilder().withTags("department:engineering", "level:senior").build()));
-
-        // Multiple tags required but person has only one matching
-        predicate = new TagContainsPredicate(Arrays.asList(
-                new TagFilter("department:engineering"),
-                new TagFilter("level:junior")));
-        assertFalse(predicate.test(new PersonBuilder().withTags("department:engineering", "level:senior").build()));
-
-        // Person has no tags
-        predicate = new TagContainsPredicate(
-                Collections.singletonList(new TagFilter("department:engineering")));
         assertFalse(predicate.test(new PersonBuilder().build()));
+    }
 
-        // Bare tag name does not match when tag is absent
-        predicate = new TagContainsPredicate(Collections.singletonList(new TagFilter("department")));
-        assertFalse(predicate.test(new PersonBuilder().withTags("role:engineering").build()));
-
-        // Same-name filters still fail when none of them match
-        predicate = new TagContainsPredicate(Arrays.asList(
+    @Test
+    public void testSameTagNameFiltersNoneMatch_returnsFalse() {
+        TagContainsPredicate predicate = new TagContainsPredicate(Arrays.asList(
                 new TagFilter("department:sales"),
                 new TagFilter("department:finance")));
         assertFalse(predicate.test(new PersonBuilder().withTags("department:engineering").build()));
+    }
 
-        // A matching same-name group is not enough when another tag-name group fails
-        predicate = new TagContainsPredicate(Arrays.asList(
+    @Test
+    public void testOneAndGroupFailsEvenWhenAnotherGroupMatches_returnsFalse() {
+        TagContainsPredicate predicate = new TagContainsPredicate(Arrays.asList(
                 new TagFilter("department:sales"),
                 new TagFilter("department:engineering"),
                 new TagFilter("level:junior")));

--- a/src/test/java/seedu/address/model/tag/TagFilterTest.java
+++ b/src/test/java/seedu/address/model/tag/TagFilterTest.java
@@ -19,7 +19,7 @@ public class TagFilterTest {
     public void constructor_nameOnly_success() {
         TagFilter tagFilter = new TagFilter("job");
 
-        assertEquals("job", tagFilter.tagName);
+        assertEquals("job", tagFilter.getTagName());
         assertFalse(tagFilter.hasTagValue());
         assertTrue(tagFilter.getTagValue().isEmpty());
     }
@@ -28,7 +28,7 @@ public class TagFilterTest {
     public void constructor_nameOnlyWithWhitespace_success() {
         TagFilter tagFilter = new TagFilter("  job title\t ");
 
-        assertEquals("job title", tagFilter.tagName);
+        assertEquals("job title", tagFilter.getTagName());
         assertFalse(tagFilter.hasTagValue());
         assertTrue(tagFilter.getTagValue().isEmpty());
     }
@@ -37,7 +37,7 @@ public class TagFilterTest {
     public void constructor_nameAndValue_success() {
         TagFilter tagFilter = new TagFilter("job:engineer");
 
-        assertEquals("job", tagFilter.tagName);
+        assertEquals("job", tagFilter.getTagName());
         assertTrue(tagFilter.hasTagValue());
         assertEquals("engineer", tagFilter.getTagValue().orElseThrow());
     }
@@ -46,7 +46,7 @@ public class TagFilterTest {
     public void constructor_nameAndValueWithWhitespace_success() {
         TagFilter tagFilter = new TagFilter(" job title :  investment banker ");
 
-        assertEquals("job title", tagFilter.tagName);
+        assertEquals("job title", tagFilter.getTagName());
         assertTrue(tagFilter.hasTagValue());
         assertEquals("investment banker", tagFilter.getTagValue().orElseThrow());
     }


### PR DESCRIPTION
Fixes #222 
Fixes #260
Fixes #275 

`filter --phone NONE` and `filter --email NONE` now filters for empty field in profiles

`filter --tag tagName:tagValue` now looks for tags with tagName by substring matching